### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_BRANCH: dev
-          BRANCH: master
+          BRANCH: main
           FOLDER: public
           CLEAN: true
-      
+
       - name: Add Contributor
         uses: akhilmhdh/contributors-readme-action@v2.0.1
         env:

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
-    "deploy": "gatsby build && gh-pages -d public -b master",
+    "deploy": "gatsby build && gh-pages -d public -b main",
     "lint": "eslint './src/**/*.{js,jsx}'",
     "alex": "alex"
   },


### PR DESCRIPTION
Resolves #22 

**Why this pull request exists?**
We want to rename the master-branch to main-branch.

**Changes made in this pull request:**
- The deploy-flow is changed to use main instead of master
- The deploy-script uses main instead of master

