### PR TITLE
Fix: SkipLink styles and add nicer hover style to Event

### DIFF
--- a/src/components/Event.jsx
+++ b/src/components/Event.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import { Link } from "gatsby"
 import PropTypes from "prop-types"
-import { colors } from "../utils/styles"
+import { colors, borderRadius } from "../utils/styles"
 import { formatDate } from "../utils/utils"
 
 const EventCard = styled.article`
@@ -14,7 +14,7 @@ const EventCard = styled.article`
   color: ${colors.darkGrey};
   line-height: 2rem;
   min-height: 13em;
-  border-radius: 0.5em;
+  border-radius: ${borderRadius.medium};
   position: relative;
   &:hover,
   &:focus-within {
@@ -27,19 +27,41 @@ const EventCard = styled.article`
   &:hover a {
     color: ${colors.darkGrey};
   }
+
+  &:focus a {
+    outline: none;
+  }
 `
 
 const EventTitle = styled.h3`
   margin-top: 0.8em;
   color: inherit;
+  box-sizing: border-box;
+  padding: 0.25em;
+  border-radius: ${borderRadius.small};
+  &:focus-within {
+    box-shadow: 0 0 0 0.25em ${colors.lightPink};
+  }
+
+  &:focus-within:hover {
+    box-shadow: none;
+  }
 
   & > a {
     color: ${colors.darkGrey};
   }
 
-  & > a:hover,
-  & > a:focus {
+  & > a:hover {
     color: ${colors.darkGrey};
+    border-bottom: 0.25rem solid ${colors.lightPink};
+  }
+
+  & > a:focus {
+    outline: none;
+  }
+
+  & > a:hover:focus {
+    box-shadow: none;
     border-bottom: 0.25rem solid ${colors.lightPink};
   }
 `

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types"
 import styled from "styled-components"
 import logo from "../../content/assets/logo.png"
 import { createGlobalStyle } from "styled-components"
-import { colors } from "../utils/styles"
+import { colors, borderRadius } from "../utils/styles"
 import { getTranslation } from "../utils/translations/helpers"
 import Footer from "./Footer"
 
@@ -24,22 +24,33 @@ const GlobalStyles = createGlobalStyle`
   }
 
   a {
-    color: ${colors.darkPink}
+    color: ${colors.darkPink};
   }
 
   a:hover {
     color: ${colors.darkGrey}
   }
+
 `
+const Header = styled.header`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
 const SkipLink = styled.a`
   color: ${colors.white};
-  background: ${colors.darkPink};
+  background: ${colors.lightPink};
   padding: 1rem;
-  position: absolute;
+  margin-top: 1rem;
   margin-bottom: 1rem;
-  transform: translateY(-100%);
+  transform: translateY(-130%);
+  font-weight: bold;
+  border-radius: ${borderRadius.small};
   &:focus {
     transform: translateY(0%);
+    outline: none;
+    box-shadow: 0 0 0 0.4em ${colors.darkPink};
   }
   &:hover {
     cursor: pointer;
@@ -70,7 +81,7 @@ const Layout = ({ children, langCode }) => {
     <>
       <GlobalStyles />
       <StyledLayout>
-        <header>
+        <Header>
           <SkipLink href="#main">
             {getTranslation(langCode, "header.skiplink")}
           </SkipLink>
@@ -80,7 +91,7 @@ const Layout = ({ children, langCode }) => {
               alt="Turku.py - programming community for women and nonbinaries"
             />
           </Link>
-        </header>
+        </Header>
         <main id="main">{children}</main>
         <Footer langCode={langCode} />
       </StyledLayout>

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -7,6 +7,6 @@ export const colors = {
 }
 
 export const borderRadius = {
-  small: "5px", // 0.3125em
-  medium: "8px", // 0.5em
+  small: "0.3125em",
+  medium: "0.5em",
 }

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -5,3 +5,8 @@ export const colors = {
   darkGrey: "#4D4E51",
   white: "#FFFFFF",
 }
+
+export const borderRadius = {
+  small: "5px", // 0.3125em
+  medium: "8px", // 0.5em
+}


### PR DESCRIPTION
**Why this pull request exists?**
I noticed that SkipLink styles aren't as nice as the rest of styles on this site, and decided to fix these styles 🤗 

**Changes made in this pull request:**
- `<SkipLink>` is now centered, has a top margin, and nice colored focus state


<img width="1298" alt="SkipLink styles and position" src="https://user-images.githubusercontent.com/1133238/95686234-3fd18e80-0c05-11eb-96f7-007fb1076e79.png">

- `<Event>` has a nicer focus state: a pink round cornered (box-)shadow

<img width="1065" alt="Event focus state" src="https://user-images.githubusercontent.com/1133238/95686304-9fc83500-0c05-11eb-89c1-f6141e78db6c.png">

- `<Event>`'s focus state is "overridden" by hover styles, if an Event is both `:focus`ed and `:hover`ed
<img width="1045" alt="Event styles on focus + hover state" src="https://user-images.githubusercontent.com/1133238/95686340-d4d48780-0c05-11eb-8647-537137863393.png">


Note: I didn't touch the global `<a> :focus` state, so in all other elements that have a `<a>`, there will be the standard/native `:focus` outline. I think this bug (and a design for them) would be worth an issue of its own.

@turkupy/turkypy-maintainers
