### PR TITLE
Add Finnish translations to three events

### DIFF
--- a/content/events/fi/career-panel/index.md
+++ b/content/events/fi/career-panel/index.md
@@ -10,8 +10,8 @@ type: "event"
 lang: fi
 ---
 
-In February we had a very exciting panel discussion by three software developers who all had very different career paths. Our meetup was hosted by Reaktor, and some Reaktorians also shared some nice summer work stories.
+Helmikuussa meillä oli erittäin jännittävä paneelikeskustelu, johon osallistui kolme ohjelmistokehittäjää, joilla kaikilla on hyvin erilaiset urapolut. Tätä tapaamista isännöi Reaktor, ja muutamat reaktorilaiset jakoivat mukavia kesätyötarinoitaan.
 
-We also had a get-to-know-each-other bingo and some pizza!
+Meillä oli myös pieni esittelykierros ja pizzaa!
 
-![The panelists having a discussion.](careerpanel.jpg)
+![Panelistit keskustelemassa.](careerpanel.jpg)

--- a/content/events/fi/machine-learning-mimosas/index.md
+++ b/content/events/fi/machine-learning-mimosas/index.md
@@ -9,13 +9,12 @@ type: "event"
 lang: fi
 ---
 
-Our December meetup with a "little xmas" theme was hosted by Anders at their Turku office.
+Joulukuun pikkujouluteemainen tapaamisemme pidettiin Andersin toimistolla Turussa.
 
-Mila presented her Mimosa machine project, which used a z-wave remote control and python to mix some drinks.
+Mila esitteli hänen Mimosa-kone-projektinsa, joka käyttää z-aaltoista kaukosäädintä ja python-ohjelmointikieltä drinkkijuomien sekoittamiseen.
 
-![Mila and the mimosa machine.](mila.jpg)
+![Mila ja mimosakone.](mila.jpg)
 
-Mathematician Eeva Rauramo held a presentation about how artificial intelligence can be used in accounting and what neural networks actually are under the hood.
+Matemaatikko Eeva Rauramo piti esityksen tekoälyn käyttämisestä laskentatoimessa ja mitä neuroverkot oikeastaan ovat konepellin alla.
 
-![Eeva presenting about neural networks.](eeva.jpg)
-
+![Eeva pitää esitystä neuroverkoista.](eeva.jpg)

--- a/content/events/fi/robotics-sunday/index.md
+++ b/content/events/fi/robotics-sunday/index.md
@@ -2,10 +2,10 @@
 title: "Robotics Sunday"
 date: "2020-08-30"
 type: "event"
-host: 
+host:
 lang: fi
 ---
 
-We spent the Sunday afternoon fiddling with the Lego Mindstorms robot. We used the VSCode Live Share feature to code simultaneously from different laptops which was very fun. We played around with the motors, sensors and sounds using the Python ev3dev module.   
+Vietimme sunnuntai-iltapäivän hypistelemällä uutta Lego Mindstorms-robottia. Käytimme VSCoden Live Share-toiminnallisuutta, jolla jaoimme saman koodin eri läppäreille samanaikaisesti, mikä oli hauskaa. Leikimme moottoreilla, sensoreilla ja äänillä käyttäen Python ev3dev-moduulia.
 
-![Playing with the robot](robotics.jpg)
+![Robotin kanssa leikkimistä.](robotics.jpg)


### PR DESCRIPTION
Add Finnish translations to three events (career panel, robotics sunday and machine learning mimosas)

Resolves #32 #37 and #41 

**Why this pull request exists?**
It is part of a larger issue (#10) to add Finnish and Swedish translations to all the content on this site.

**Changes made in this pull request:**
- Finnish translations to events' index.md

@turkupy/turkypy-maintainers
