### PR TITLE
Remove tagging from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,3 @@ Resolves # .
 -
 -
 
-@turkupy/turkypy-maintainers


### PR DESCRIPTION
**Why this pull request exists?**
The added tagging is not working, so this PR removes it from the PR template.

**Changes made in this pull request:**
- Tagging of Turkupy-maintainers is removed

