### PR TITLE
Fix/ Get titles from translations instead of hardcoded strings

### DIFF
--- a/src/components/stats/BarChart.jsx
+++ b/src/components/stats/BarChart.jsx
@@ -1,0 +1,17 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+const BarChart = ({ data }) => {
+  console.log(data)
+  return (
+    <div>
+      <svg id="chart" />
+    </div>
+  )
+}
+
+BarChart.propTypes = {
+  data: PropTypes.any,
+}
+
+export default BarChart

--- a/src/templates/EventsPage.jsx
+++ b/src/templates/EventsPage.jsx
@@ -5,6 +5,7 @@ import Layout from "../components/Layout"
 import SEO from "../components/Seo"
 import Events from "../components/Events"
 import { getLangCode } from "../utils/utils"
+import { getTranslation } from "../utils/translations/helpers"
 
 const EventsPage = ({ data, location }) => {
   const { pathname } = location
@@ -16,9 +17,9 @@ const EventsPage = ({ data, location }) => {
   return (
     <Layout title={siteTitle} langCode={langCode}>
       <SEO title={siteTitle} />
-      <h2>Upcoming Events</h2>
+      <h2>{getTranslation(langCode, "frontpage.upcoming-events")}</h2>
       <Events events={upcomingEvents} />
-      <h2>Past Events</h2>
+      <h2>{getTranslation(langCode, "frontpage.past-events")}</h2>
       <Events events={pastEvents} />
     </Layout>
   )


### PR DESCRIPTION
**Why this pull request exists?**
There were some hardcoded strings in Events page, and they need to come from translations.

